### PR TITLE
Added getAdditionalAmrsOrNull method into PersonAuthenticationType

### DIFF
--- a/oxService/src/main/java/org/xdi/model/custom/script/type/auth/DummyPersonAuthenticationType.java
+++ b/oxService/src/main/java/org/xdi/model/custom/script/type/auth/DummyPersonAuthenticationType.java
@@ -6,11 +6,11 @@
 
 package org.xdi.model.custom.script.type.auth;
 
-import java.util.List;
-import java.util.Map;
-
 import org.xdi.model.AuthenticationScriptUsageType;
 import org.xdi.model.SimpleCustomProperty;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Dummy implementation of interface PersonAuthenticationType
@@ -27,6 +27,11 @@ public class DummyPersonAuthenticationType implements PersonAuthenticationType {
 	@Override
 	public boolean destroy(Map<String, SimpleCustomProperty> configurationAttributes) {
 		return true;
+	}
+
+	@Override
+	public Map<String, String> getAdditionalAmrsOrNull() {
+		return null;
 	}
 
 	@Override

--- a/oxService/src/main/java/org/xdi/model/custom/script/type/auth/PersonAuthenticationType.java
+++ b/oxService/src/main/java/org/xdi/model/custom/script/type/auth/PersonAuthenticationType.java
@@ -6,12 +6,12 @@
 
 package org.xdi.model.custom.script.type.auth;
 
-import java.util.List;
-import java.util.Map;
-
 import org.xdi.model.AuthenticationScriptUsageType;
 import org.xdi.model.SimpleCustomProperty;
 import org.xdi.model.custom.script.type.BaseExternalType;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Base interface for external authentication python script
@@ -19,6 +19,8 @@ import org.xdi.model.custom.script.type.BaseExternalType;
  * @author Yuriy Movchan Date: 08/21/2012
  */
 public interface PersonAuthenticationType extends BaseExternalType {
+
+	public Map<String, String> getAdditionalAmrsOrNull();
 
 	public boolean isValidAuthenticationMethod(AuthenticationScriptUsageType usageType, Map<String, SimpleCustomProperty> configurationAttributes);
 


### PR DESCRIPTION
Added getAdditionalAmrsOrNull method into PersonAuthenticationType to allow custom authentication scripts to return additional amr values. This request coupled with https://github.com/GluuFederation/oxAuth/issues/244 issue
