### PR TITLE
Samlsignature

### DIFF
--- a/oxSaml/pom.xml
+++ b/oxSaml/pom.xml
@@ -82,5 +82,25 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.opensaml</groupId>
+			<artifactId>opensaml</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.opensaml</groupId>
+			<artifactId>xmltooling</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.opensaml</groupId>
+			<artifactId>openws</artifactId>
+			<version>1.4.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.ws.security</groupId>
+			<artifactId>wss4j</artifactId>
+			<version>1.6.17</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/oxSaml/src/main/java/org/gluu/saml/Response.java
+++ b/oxSaml/src/main/java/org/gluu/saml/Response.java
@@ -46,7 +46,7 @@ import org.xml.sax.SAXException;
 
 /**
  * Loads and validates SAML response
- * 
+ *
  * @author Yuriy Movchan Date: 24/04/2014
  */
 public class Response {
@@ -163,8 +163,8 @@ public class Response {
 			for (int j = 0; j < nameChildNodes.getLength(); j++) {
 				Node nameChildNode = nameChildNodes.item(j);
 
-				if (nameChildNode.getNamespaceURI().equalsIgnoreCase("urn:oasis:names:tc:SAML:2.0:assertion")
-						&& nameChildNode.getLocalName().equals("AttributeValue")) {
+				if ("urn:oasis:names:tc:SAML:2.0:assertion".equalsIgnoreCase(nameChildNode.getNamespaceURI())
+						&& "AttributeValue".equals(nameChildNode.getLocalName())) {
 					NodeList valueChildNodes = nameChildNode.getChildNodes();
 					for (int k = 0; k < valueChildNodes.getLength(); k++) {
 						Node valueChildNode = valueChildNodes.item(k);

--- a/oxSaml/src/main/java/org/gluu/saml/SamlConfiguration.java
+++ b/oxSaml/src/main/java/org/gluu/saml/SamlConfiguration.java
@@ -6,8 +6,23 @@
 
 package org.gluu.saml;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+
+import org.apache.ws.security.saml.ext.OpenSAMLUtil;
+import org.opensaml.xml.security.credential.BasicCredential;
+import org.opensaml.xml.security.credential.Credential;
+import org.opensaml.xml.security.credential.UsageType;
+import org.opensaml.xml.signature.SignatureConstants;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang.exception.CloneFailedException;
@@ -15,7 +30,7 @@ import org.xdi.util.security.CertificateHelper;
 
 /**
  * Configuration settings
- * 
+ *
  * @author Yuriy Movchan Date: 24/04/2014
  */
 public class SamlConfiguration {
@@ -26,6 +41,12 @@ public class SamlConfiguration {
 	private String nameIdentifierFormat;
 	private X509Certificate certificate;
 	private boolean useRequestedAuthnContext;
+
+	protected PrivateKey privateKey;
+	protected String _sigAlg = "SHA256withRSA";
+	protected String _sigAlgUrl = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+
+
 
 	public String getIdpSsoTargetUrl() {
 		return idpSsoTargetUrl;
@@ -88,4 +109,56 @@ public class SamlConfiguration {
 		}
 	}
 
+
+	public String getSigAlg() {
+		return _sigAlg;
+	}
+	public void setSigAlg(String val) {
+		this._sigAlg = val;
+	}
+
+	public String getSigAlgUrl() {
+		return _sigAlgUrl;
+	}
+	public void setSigAlgUrl(String val) {
+		this._sigAlgUrl = val;
+	}
+
+	public PrivateKey getPrivateKey() {
+		return privateKey;
+	}
+	public void setPrivateKey(PrivateKey val) {
+		this.privateKey = val;
+	}
+
+	/**
+	 * loads the private key for digital signature
+	 * @param prvKeyPath file path to location of private key
+	 * @throws Exception
+	 */
+	public void loadPrivateKey(String prvKeyPath) throws Exception {
+		OpenSAMLUtil.initSamlEngine();
+
+		File privKeyFile = new File(prvKeyPath);
+		BufferedInputStream bis = null;
+		try {
+			bis = new BufferedInputStream(new FileInputStream(privKeyFile));
+		} catch (FileNotFoundException e) {
+			throw new Exception("Could not locate keyfile at '" + prvKeyPath + "'", e);
+		}
+		byte[] privKeyBytes = new byte[(int) privKeyFile.length()];
+		bis.read(privKeyBytes);
+		bis.close();
+		KeySpec ks = new PKCS8EncodedKeySpec(privKeyBytes);
+		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+		privateKey = keyFactory.generatePrivate(ks);
+	}
+
+	protected Credential getCredential() {
+		BasicCredential credential = new BasicCredential();
+		credential.setPublicKey(certificate.getPublicKey());
+		credential.setPrivateKey(privateKey);
+		credential.setUsageType(UsageType.SIGNING);
+		return credential;
+	}
 }


### PR DESCRIPTION
Here is the updated code to handle at the very least digitally signing an AuthnRequest for a HTTP-Redirect request.  This will require change in the jython SamlExternalAuthenticator.py to leverage the updated AuthRequest class.  You will need to add a new parameters called "asimba_saml_privkey_file" and load it into the SamlConfiguration instance using the loadPrivateKey method so it can be available for the AuthRequest class the public key will be gotten from the certificate loading process that already exists.  The private key needs to be in pkcs8 format and not in the PEM string format.  I did not update the jython script file because in my version we added too much custom code specific to our company, but I thought it would not be too hard for you guys to update the script to conform to the new AuthRequest object.

It should go something like this.
----------------
def init(self, configurationAttributes):
...
samlConfiguration.loadPrivateKey(configurationAttributes.get("asimba_saml_privkey_file").getValue2())
...

def prepareForStep(self, configurationAttributes, requestParameters, step):
...
samlAuthRequest = AuthRequest(currentSamlConfiguration)
qryString = getRedirectRequestSignedQueryParams(assertionConsumerServiceUrl, "")
external_auth_request_uri = currentSamlConfiguration.getIdpSsoTargetUrl() + "?"+ qryString
...
----------------

As a side note I originally went down the wrong path of trying to sign the AuthnRequest by using an enveloped digital signature but didn't realize that this was only used for a POST AuthnRequest.  So I have not really tested a POST request but I thought it might be useful for you to have this code.  Although the code will generate the SAML enveloped xml string which I assume you can place in a POST request there was no way for me to test this since the jython script only allowed for HTTP-Redirect and only now made real sense in hindsight for an SP and not for a proxy IDP.

I hope this works for you guys and makes it into the master branch ;)
